### PR TITLE
chore: update to ACA-py 0.8.0

### DIFF
--- a/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.param
+++ b/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.param
@@ -9,5 +9,5 @@ GIT_REPO_URL=https://github.com/hyperledger/aries-mediator-service.git
 GIT_REF=main
 SOURCE_CONTEXT_DIR=
 DOCKER_FILE_PATH=./acapy/Dockerfile.acapy
-SOURCE_IMAGE=artifacts.developer.gov.bc.ca/docker-remote/bcgovimages/von-image:py36-1.16-1
+SOURCE_IMAGE=artifacts.developer.gov.bc.ca/github-docker-remote/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.0-rc0
 OUTPUT_IMAGE_TAG=latest

--- a/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.yaml
+++ b/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.yaml
@@ -21,23 +21,33 @@ objects:
         - type: ImageChange
         - type: ConfigChange
       runPolicy: Serial
-      source:
-        type: Git
-        git:
-          uri: ${GIT_REPO_URL}
-          ref: ${GIT_REF}
-        contextDir: ${SOURCE_CONTEXT_DIR}
-      strategy:
-        type: Docker
-        dockerStrategy:
-          from:
-            kind: DockerImage
-            name: ${SOURCE_IMAGE}
-          dockerfilePath: ${DOCKER_FILE_PATH}
+    strategy:
+      type: Docker
+    source:
+      type: Git
+      git:
+        uri: "https://github.com/bcgov/openshift-aries-mediator-service.git"
+        ref: main
       output:
         to:
           kind: ImageStreamTag
           name: ${NAME}:${OUTPUT_IMAGE_TAG}
+      dockerfile: >
+        FROM
+        artifacts.developer.gov.bc.ca/github-docker-remote/hyperledger/aries-cloudagent-python:py3.9-indy-1.16.0-0.8.0-rc0
+
+        USER root
+
+        # The root group needs access the directories under $HOME/.indy_client for
+        # the container to function in OpenShift. Also ensure the permissions on 
+        # python 'site-packages' folder are set correctly.
+
+        RUN chown -R indy:root $HOME/.indy_client \
+            && chmod -R ug+rw $HOME/log $HOME/ledger $HOME/.aries_cloudagent $HOME/.cache $HOME/.indy-cli $HOME/.indy_client \
+            && chmod +rx $(python -m site --user-site)
+
+        USER $user
+
 parameters:
   - name: NAME
     displayName: Name
@@ -48,37 +58,12 @@ parameters:
     displayName: Suffix
     description: A name suffix used for all objects
     required: false
-    value: 
+    value:
   - name: APP_NAME
     displayName: App Name
     description: Used to group components together.
     required: true
     value: aries-mediator-service
-  - name: GIT_REPO_URL
-    displayName: Git Repo URL
-    description: The URL to your GIT repo.
-    required: true
-    value: https://github.com/hyperledger/aries-mediator-service.git
-  - name: GIT_REF
-    displayName: Git Reference
-    description: The git reference or branch.
-    required: true
-    value: main
-  - name: SOURCE_CONTEXT_DIR
-    displayName: Source Context Directory
-    description: The source context directory.
-    required: false
-    value: ''
-  - name: DOCKER_FILE_PATH
-    displayName: Docker File Path
-    description: The path to the docker file defining the build.
-    required: false
-    value: ./acapy/Dockerfile.acapy
-  - name: SOURCE_IMAGE
-    displayName: Source Image
-    description: The fully-qualified name of the source image for this component. 
-    required: true
-    value: artifacts.developer.gov.bc.ca/docker-remote/bcgovimages/von-image:py36-1.16-1
   - name: OUTPUT_IMAGE_TAG
     displayName: Output Image Tag
     description: The tag given to the built image.

--- a/openshift/templates/aries-mediator-agent/aries-mediator-agent-deploy.yaml
+++ b/openshift/templates/aries-mediator-agent/aries-mediator-agent-deploy.yaml
@@ -93,7 +93,7 @@ objects:
       seed: ${WALLET_SEED}
       key: ${WALLET_KEY}
     type: Opaque
-  
+
   - kind: Secret
     apiVersion: v1
     metadata:
@@ -146,20 +146,20 @@ objects:
               command:
                 - bash
                 - -c
-                - $(echo aca-py start --auto-provision 
-                  --arg-file ${MEDIATOR_ARG_FILE} 
-                  --inbound-transport http 0.0.0.0 ${MEDIATOR_AGENT_HTTP_IN_PORT} 
-                  --inbound-transport ws 0.0.0.0 ${MEDIATOR_AGENT_WS_IN_PORT} 
-                  --outbound-transport ws 
-                  --outbound-transport http 
-                  --emit-new-didcomm-prefix 
+                - $(echo aca-py start --auto-provision
+                  --arg-file ${MEDIATOR_ARG_FILE}
+                  --inbound-transport http 0.0.0.0 ${MEDIATOR_AGENT_HTTP_IN_PORT}
+                  --inbound-transport ws 0.0.0.0 ${MEDIATOR_AGENT_WS_IN_PORT}
+                  --outbound-transport ws
+                  --outbound-transport http
+                  --emit-new-didcomm-prefix
                   --endpoint ${AGENT_URL} ${AGENT_WS_URL}
-                  --wallet-type indy 
+                  --wallet-type indy
                   --wallet-storage-type postgres_storage
                   --wallet-storage-config "$(eval echo \"${WALLET_STORAGE_CONFIGURATION}\")"
                   --wallet-storage-creds "$(eval echo \"${WALLET_STORAGE_CREDENTIALS}\")"
-                  --admin 0.0.0.0 ${MEDIATOR_AGENT_HTTP_ADMIN_PORT} 
-                  --admin-api-key ${MEDIATOR_AGENT_ADMIN_MODE} 
+                  --admin 0.0.0.0 ${MEDIATOR_AGENT_HTTP_ADMIN_PORT}
+                  --admin-api-key ${MEDIATOR_AGENT_ADMIN_MODE}
                   --webhook-url ${MEDIATOR_CONTROLLER_WEBHOOK}
                   );
               env:
@@ -226,6 +226,10 @@ objects:
                 - name: ACAPY_READ_ONLY_LEDGER
                   value: ${AGENT_READ_ONLY_LEDGER}
               image: " "
+              volumeMounts:
+                - name: config
+                  mountPath: /home/indy/configs/mediator-auto-accept.yml
+                  subPath: mediator-auto-accept.yml
               ports:
                 - containerPort: ${{INDY_ADMIN_PORT}}
                   protocol: TCP
@@ -260,6 +264,10 @@ objects:
           schedulerName: default-scheduler
           securityContext: {}
           terminationGracePeriodSeconds: 30
+          volumes:
+            - name: config
+              configMap:
+                name: mediator-config
       triggers:
         - type: ConfigChange
         - type: ImageChange
@@ -307,6 +315,38 @@ objects:
         scaleDown:
           stabilizationWindowSeconds: 300
 
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: mediator-config
+    data:
+      mediator-auto-accept.yml: |-
+        # General settings for mediator agent
+
+        # Mediator does not use a ledger
+        no-ledger: true
+
+        # Wallet
+        wallet-type: indy
+        wallet-name: mediator
+        wallet-key: insecure, for testing purposes only
+        auto-provision: true
+
+        # Mediation
+        open-mediation: true
+        enable-undelivered-queue: true
+
+        # Connections
+        debug-connections: true
+        auto-accept-invites: true
+        auto-accept-requests: true
+        auto-ping-connection: true
+
+        # Print an admin invite
+        connections-invite: true
+        invite-label: "Mediator"
+        invite-multi-use: true
+
 parameters:
   - name: NAME
     displayName: Name
@@ -332,7 +372,7 @@ parameters:
     displayName: Suffix
     description: A name suffix used for all objects
     required: false
-    value: ''
+    value: ""
   - name: ROLE
     displayName: Role
     description: The role of this service within the application - used for Network Policies
@@ -429,7 +469,7 @@ parameters:
     displayName: Site URL
     description: The URL for the site
     required: true
-    value: wss://aries-mediator-agent-dev.apps.silver.devops.gov.bc.ca 
+    value: wss://aries-mediator-agent-dev.apps.silver.devops.gov.bc.ca
   - name: GENESIS_FILE_URL
     displayName: Genesis File URL
     description: The URL from which the genesis file can be downloaded.


### PR DESCRIPTION
Updated the deployment base image for ACA-py for the OpenShift build from 0.7.4 to 0.8.0. The new images don't need anything from the Aries mediator. So the build no longer pulls the Dockerifle from there. Rather it uses an in-line Dockerfile to update file system permissions for OpenShift. It also moves the ACA-py config file to a ConfigMap for easier updates and better visibility.