### PR TITLE
Enable mediator mode on the persistent queue

### DIFF
--- a/openshift/templates/aries-mediator-agent/config/default/plugins-config.yml
+++ b/openshift/templates/aries-mediator-agent/config/default/plugins-config.yml
@@ -12,7 +12,7 @@ redis_queue:
   outbound:
     # The topic names are overridden by startup settings
     acapy_outbound_topic: "acapy_outbound"
-    mediator_mode: false
+    mediator_mode: true
 
   ### For Event ###
   event:


### PR DESCRIPTION
It appears we've had the mediator's persistent queue misconfigured for some time.  This update addresses that issue.

Fixes: #38 