### PR TITLE
Upgrade mediator to aca-py 1.1.0

### DIFF
--- a/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.param
+++ b/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.param
@@ -10,5 +10,5 @@ GIT_REPO_URL=https://github.com/bcgov/openshift-aries-mediator-service.git
 GIT_REF=main
 SOURCE_CONTEXT_DIR=./openshift/templates/aries-mediator-agent/container
 DOCKER_FILE_PATH=Dockerfile
-SOURCE_IMAGE=artifacts.developer.gov.bc.ca/github-docker-remote/hyperledger/aries-cloudagent-python:py3.9-0.10.4
+SOURCE_IMAGE=artifacts.developer.gov.bc.ca/github-docker-remote/openwallet-foundation/acapy-agent:py3.12-1.1.0
 OUTPUT_IMAGE_TAG=latest

--- a/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.yaml
+++ b/openshift/templates/aries-mediator-agent/aries-mediator-agent-build.yaml
@@ -79,7 +79,7 @@ parameters:
     displayName: Source Image
     description: The fully-qualified name of the source image for this component.
     required: true
-    value: artifacts.developer.gov.bc.ca/github-docker-remote/hyperledger/aries-cloudagent-python:py3.9-0.10.4
+    value: artifacts.developer.gov.bc.ca/github-docker-remote/openwallet-foundation/acapy-agent:py3.12-1.1.0
   - name: OUTPUT_IMAGE_TAG
     displayName: Output Image Tag
     description: The tag given to the built image.

--- a/openshift/templates/aries-mediator-agent/container/Dockerfile
+++ b/openshift/templates/aries-mediator-agent/container/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.10.4
+FROM ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.1.0
 
 # ========================================================================================================================================
 # Install Plugins
 # ----------------------------------------------------------------------------------------------------------------------------------------
 # Redis PQ
-RUN pip install --no-cache-dir git+https://github.com/hyperledger/aries-acapy-plugins.git@main#subdirectory=redis_events
+RUN pip install --no-cache-dir git+https://github.com/openwallet-foundation/acapy-plugins.git@main#subdirectory=redis_events
 # Firebase Push Notifications
-RUN pip install --no-cache-dir -e "git+https://github.com/hyperledger/aries-mediator-service.git@main#egg=firebase_push_notifications&subdirectory=acapy/plugins/firebase_push_notifications"
+RUN pip install --no-cache-dir git+https://github.com/openwallet-foundation/acapy-plugins.git@main#subdirectory=firebase_push_notifications
 # ========================================================================================================================================


### PR DESCRIPTION
- Migrate image and repository references to OpenWallet Foundation repositories.